### PR TITLE
POSTS to Genome Nexus are sorted and unsorted

### DIFF
--- a/annotator/src/main/java/org/cbioportal/annotator/Annotator.java
+++ b/annotator/src/main/java/org/cbioportal/annotator/Annotator.java
@@ -50,4 +50,5 @@ public interface Annotator {
     String getUrlForRecord(MutationRecord record, String isoformOverridesSource);
     String getVersion();
     List<AnnotatedRecord> getAnnotatedRecordsUsingPOST(AnnotationSummaryStatistics summaryStatistics, List<MutationRecord> mutationRecords, String isoformOverridesSource, Boolean replace) throws Exception;
+    List<AnnotatedRecord> getAnnotatedRecordsUsingPOST(AnnotationSummaryStatistics summaryStatistics, List<MutationRecord> mutationRecords, String isoformOverridesSource, Boolean replace, Integer postIntervalSize) throws Exception;
 }

--- a/annotator/src/main/java/org/cbioportal/annotator/internal/AnnotationSummaryStatistics.java
+++ b/annotator/src/main/java/org/cbioportal/annotator/internal/AnnotationSummaryStatistics.java
@@ -90,6 +90,7 @@ private final List<String> ERROR_FILE_HEADER = Arrays.asList(new String[]{"SAMPL
         Boolean failedAnnotation = Boolean.FALSE;
         if (MafUtil.variantContainsAmbiguousTumorSeqAllele(record.getREFERENCE_ALLELE(),
                 record.getTUMOR_SEQ_ALLELE1(), record.getTUMOR_SEQ_ALLELE2())) {
+            System.out.println("variantContainsAmbiguousTumorSeqAllele"); 
             this.ambiguousTumorSeqAlleleRecords++;
             this.failedAnnotatedRecordsErrorMessages.add(
                     constructErrorMessageFromRecord(record,
@@ -101,7 +102,9 @@ private final List<String> ERROR_FILE_HEADER = Arrays.asList(new String[]{"SAMPL
 
         }
         if (annotatedRecord.getHGVSC().isEmpty() && annotatedRecord.getHGVSP().isEmpty()) {
+            System.out.println("getHGVSC().isEmpty() && getHGVSP().isEmpty()"); 
             if (annotator.isHgvspNullClassifications(annotatedRecord.getVARIANT_CLASSIFICATION())) {
+                System.out.println("isHgvspNullClassifications"); 
                 this.nullVariantClassificationRecords++;
                 this.failedAnnotatedRecordsErrorMessages.add(
                         constructErrorMessageFromRecord(record,
@@ -111,6 +114,7 @@ private final List<String> ERROR_FILE_HEADER = Arrays.asList(new String[]{"SAMPL
                 );
                 failedAnnotation = Boolean.TRUE;
             } else {
+                System.out.println("this.otherFailedAnnotatedRecords"); 
                 this.otherFailedAnnotatedRecords++;
                 this.failedAnnotatedRecordsErrorMessages.add(
                         constructErrorMessageFromRecord(record,


### PR DESCRIPTION
POSTS to Genome Nexus are sorted and unsorted so that Genome Nexus can most efficiently use indexing.

NOTE when I run this on the following file, it is failing to annotate because getHGVSC().isEmpty() && getHGVSP().isEmpty().  If you don't have that line, the output file is annotated (but those columns are empty).  Maybe I am testing on a bad file?  But the sorting and unsorting works, and it does call Genome Nexus and does handle the results.

 - Moved partitioning to GenomeNexusImpl
    * It can be used by all clients
    * GenomeNexusImpl merges Genome Nexus results with the original MutationRecord, so it is best to have all records here
 - Added sorting of GenomicLocations to GenomeNexusImpl
 - Temporary debugging System.out.println statements in AnnotationSummaryStatistics.java

- [ ] TODO the Comparator in GenomeNexusImpl that sorts GenomicLocation does not check if objects are null.  They probably cannot be, but maybe make a comment that they can't be so we don't check for null.

- [ ] TODO Remove debugging info in AnnotationSummaryStatistics.java, and all other System.out.println statements

- [ ] TODO LOG.WARN for this case on line 588 of `GenomeNexusImpl`: `summaryStatistics.isFailedAnnotatedRecord(annotatedRecord, record, isoformOverridesSource)`

- [ ] TODO Make the GenomicLocations a Set and then sort or a SortedSet, because then we would not do any duplicate querying of Genome Nexus.  See if this is faster on a large study than having a list of GenomeLocations that contains duplicates which is then sorted.